### PR TITLE
Refactor: import/export 경로 수정 및 번들러 동작 확인

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -10,7 +10,7 @@ const CommandLineInterface = () => {
     const currentOption = buildQueue.dequeue();
     if (currentOption.startsWith('-')) {
       const requireSource = [];
-      const { optionFunction, requireSourceCount } = OPTION[currentOption];
+      const { function: optionFunction, requireSource: requireSourceCount } = OPTION[currentOption];
 
       for (let i = 0; i < requireSourceCount; i++) {
         if (!buildQueue.size()) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import ModuleCompiler from './parser/index.js';
 import CommandLineInterface from './cli/index.js';
+import { runtimeTemplate, moduleMapTemplate } from './output/template.js';
+import { createOutputFile } from './output/index.js';
 
 class KimbapBundler {
   constructor({ entry, output, ast }) {
@@ -9,7 +11,7 @@ class KimbapBundler {
 
   build() {
     const moduleCompiler = new ModuleCompiler(this.entry);
-    const { moduleList } = moduleCompiler.run(ast);
+    const { moduleList } = moduleCompiler.run();
      
     const entryFilePath = moduleList[0].filePath;
     const outputContent = runtimeTemplate(
@@ -17,7 +19,7 @@ class KimbapBundler {
       entryFilePath,
     );
     
-    createOutputFile({ output }, outputContent);
+    createOutputFile(this.output, outputContent);
   }
 }
 

--- a/src/output/index.js
+++ b/src/output/index.js
@@ -1,5 +1,5 @@
-import PathUtil from '../util/path';
-import FileUtil from '../util/file';
+import PathUtil from '../util/path.js';
+import FileUtil from '../util/file.js';
 
 /**
  * create output directory 
@@ -21,15 +21,11 @@ const createOutputDirectory = (directoryPath) => {
  * @param {object} configs 
  * @param {string} outputContent 
  */
-const createOutputFile = (configs, outputContent) => {
-    const { output } = configs || {};
+export const createOutputFile = (output, outputContent) => {
+    const { path, filename } = output;
 
-    const directoryPath = createOutputDirectory(output.path);
-    const filePath = PathUtil.join([directoryPath, output.filename]);
+    const directoryPath = createOutputDirectory(path);
+    const filePath = PathUtil.join([directoryPath, filename]);
 
     FileUtil.createFile(filePath, outputContent);
-}
-
-module.exports = {
-    createOutputFile
 }

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -119,7 +119,7 @@ class ModuleCompiler {
       let mainPath = jsonContent.module || jsonContent.main || undefined;
 
       if (mainPath) {
-        return resolve(packagePath, main);
+        return resolve(packagePath, mainPath);
       }
     }
 

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -1,6 +1,6 @@
 import { dirname, resolve } from 'path';
 import { parseSync } from '@babel/core';
-import { transform } from '../transform/index.js'
+import transform from '../transform/index.js'
 import Queue from '../util/queue.js';
 import PathUtil from '../util/path.js';
 


### PR DESCRIPTION
### 작업 내용
- 각자 작업 머지 후 import/export 경로들이 안 맞는 경우가 있어 수정해두었습니다.
- 경로 수정 후 그냥 돌릴 시, maximum call size 초과 에러 나서 runtime template 에 cache 적용했습니다.
- 동작 후 코드 상 에러 나는 부분 수정했습니다.
### 번들러 동작 확인
#### cli
- help 와 같은 옵션에선 build 함수 실행 안하도록 조치 필요
<img width="552" alt="image" src="https://github.com/danmooozi/kimbap.js/assets/20807197/d38677e7-2b2c-4a3f-89d2-dfcce3cbc858">   

#### example1
- 정상 동작
<img width="717" alt="image" src="https://github.com/danmooozi/kimbap.js/assets/20807197/1a831833-3dca-40ac-8478-72509f9239d2">

#### example3
- 에러
<img width="719" alt="image" src="https://github.com/danmooozi/kimbap.js/assets/20807197/1ea5ceb5-a63d-4656-ad0d-4d97126c8b63">
