### PR TITLE
배포 커맨드

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: Auto-generated release from GitHub Actions.
+          draft: false
+          prerelease: false

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.prettierrc
+.gitignore
+README.md
+node_modules
+example

--- a/README.md
+++ b/README.md
@@ -1,4 +1,23 @@
 # kimbap.js
-JavaScript bundler 
 
 ![image](https://github.com/danmooozi/kimbap.js/assets/20807197/1c70accd-9d07-4ee6-8b3f-ff07b6e9b1dd)
+
+It is JavaScript bundler.
+
+## Install
+
+```bash
+npm install kimbap.js
+```
+
+## Usage
+
+```bash
+    Usage: kimbap [options] <source ...>
+
+    Options:
+        -e, --entry <path>    Entry file path
+        -o, --output <path>   Output file path
+        -d, --dist <filename> Output file name
+        -h, --help            Output usage information
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "JavaScript bundler",
   "main": "index.js",
   "scripts": {
-    "test": "node --trace-warnings --experimental-vm-modules ./node_modules/.bin/jest"
+    "test": "node --trace-warnings --experimental-vm-modules ./node_modules/.bin/jest",
+    "publish": "npm version patch && git push --follow-tags && npm publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- npm 에서 기본으로 올려주는 커맨드가 있어서 패치 업데이트 커맨드 사용
- actions 은 tag push 할때마다 release 만드는 식으로 만듬. ( 테스트 안해봄 )
- npm 올라갈꺼니깐 npm ignore
- README.md 너무 허전해서 조금 채움