### PR TITLE
fix: node_modules 폴더를 찾을 수 없을 경우 Error throw

### DIFF
--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -101,6 +101,10 @@ class ModuleCompiler {
       rootPath = dirname(rootPath);
     }
 
+    if (!rootPath.includes('node_modules')) {
+      throw new Error('프로젝트 내에서 node_modules 폴더를 찾을 수 없습니다.')
+    }
+
     // node_modules 탐색 종료 후, 해당 위치를 기반으로 package의 경로를 추출
     let packagePath = resolve(rootPath, 'node_modules', modulePath);
 


### PR DESCRIPTION
## 작업 내용
- `node_modules` 폴더가 프로젝트 폴더 내부에 없을 경우 throw Error 하도록 수정
- 기존에 로아가 테스트 해주셨던 example3 가 왜 안될까 봤는데 npm install 로 `node_modules` 을 생성하지 않아 발생한 문제였습니다.
- 따라서 이러한 문제를 미연에 방지하기 위해서 node_modules 폴더가 없을 경우 전용 Error 를 던지도록 수정했어요.

![223](https://github.com/danmooozi/kimbap.js/assets/74497253/e9e7ab83-2ea0-495d-bce2-6a65205cea27)

## 잡담
- Uglify 구조 파악하는데 상당히 많은 애를 먹고 있습니다. 진짜 코드가 대박이에요..
- [진짜 말로 표현할 수 없을 정도로 복잡한 코드](https://github.com/mishoo/UglifyJS/blob/master/lib/minify.js)